### PR TITLE
Bump chrono-tz to 0.6

### DIFF
--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 [dependencies]
 async-trait = "0.1.50"
 chrono = { version = "0.4", default-features = false, features = ["wasmbind"] }
-chrono-tz = { version = "0.4", default-features = false }
+chrono-tz = { version = "0.6", default-features = false }
 futures = "0.3.16"
 http = "0.2.4"
 js-sys = "0.3.55"


### PR DESCRIPTION
`chrono-tz` 0.4 does not disable `chrono`'s default features, which include the feature `oldtime` that depends on an obsolete version of the `time` crate that is vulnerable to [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159).

Besides, `chrono-tz` 0.4.1 [does not have any default features](https://github.com/chronotope/chrono-tz/blob/aa553ccc060404da7c65cfae1c136c949c6fbf1c/Cargo.toml) that can be disabled.